### PR TITLE
tcpdump now uses autogen.sh to generate the configure script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
                     cd ..
                     git clone --depth 3 --branch=master --quiet https://github.com/the-tcpdump-group/tcpdump.git
                     cd tcpdump
+                    ./autogen.sh
                     ./configure --prefix=/tmp
                     make
                     sudo make install


### PR DESCRIPTION
https://github.com/the-tcpdump-group/tcpdump/commit/15e642a9cd3dd1118d2c3185e8124ea3ec94f7f8