### PR TITLE
Add invalid marking of unknown OSPFv2 LS-types

### DIFF
--- a/format.go
+++ b/format.go
@@ -314,6 +314,7 @@ func formatPacketUDP(packet *gopacket.Packet, udp *layers.UDP, src, dst string) 
 
 func formatPacketOSPF(ospf layers.OSPF, src, dst string, length int) string {
 	var ospfType string
+	var invalid string
 	switch ospf.Type {
 	case layers.OSPFHello:
 		ospfType = "Hello"
@@ -330,9 +331,10 @@ func formatPacketOSPF(ospf layers.OSPF, src, dst string, length int) string {
 			ospfType = fmt.Sprintf("unknown packet type (%d)", ospf.Type)
 		} else {
 			ospfType = fmt.Sprintf("unknown LS-type %d", ospf.Type)
+			invalid = " (invalid)"
 		}
 	}
-	return fmt.Sprintf("%s > %s: OSPFv%d, %s, length %d", src, dst, ospf.Version, ospfType, length)
+	return fmt.Sprintf("%s > %s: OSPFv%d, %s, length %d%s", src, dst, ospf.Version, ospfType, length, invalid)
 }
 
 func formatPacketGRE(gre *layers.GRE, src, dst string, length int) string {


### PR DESCRIPTION
Upstream tcpdump behavior change: https://github.com/the-tcpdump-group/tcpdump/pull/1438/changes#diff-70626025411d153b8cca3ba7d11a76678c8cac6933672285a352f63be7539ea8L1479